### PR TITLE
Door opening and rendering fixes + new spook mechanic

### DIFF
--- a/common/src/main/java/net/blay09/mods/spookydoors/SpookyDoors.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/SpookyDoors.java
@@ -17,6 +17,7 @@ public class SpookyDoors {
         ModItems.initialize(Balm.getItems());
         ModNetworking.initialize(Balm.getNetworking());
         ModSounds.initialize(Balm.getSounds());
+        SpookyDoorsConfig.initialize();
     }
 
 }

--- a/common/src/main/java/net/blay09/mods/spookydoors/SpookyDoorsConfigData.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/SpookyDoorsConfigData.java
@@ -5,16 +5,9 @@ import net.blay09.mods.balm.api.config.Comment;
 import net.blay09.mods.balm.api.config.Config;
 import net.blay09.mods.balm.api.config.ExpectedType;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Config(SpookyDoors.MOD_ID)
 public class SpookyDoorsConfigData implements BalmConfigData {
-    @Comment("IDs of inbuilt rulesets to enable. For example, \"waystones:generated_waystones\" makes all generated waystones unbreakable.")
-    @ExpectedType(String.class)
-    public List<String> rulesets = new ArrayList<>();
-
-    @Comment("List of custom rules with comma-separated parameters in parentheses. Conditions can be defined as comma-separated list in square brackets. Will be applied in order.")
-    @ExpectedType(String.class)
-    public List<String> rules = new ArrayList<>();
+    @Comment("Make the doors randomly open slightly. Doesn't affect gameplay.")
+    @ExpectedType(Boolean.class)
+    public Boolean random_spook = Boolean.FALSE;
 }

--- a/common/src/main/java/net/blay09/mods/spookydoors/SpookyDoorsConfigData.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/SpookyDoorsConfigData.java
@@ -8,6 +8,6 @@ import net.blay09.mods.balm.api.config.ExpectedType;
 @Config(SpookyDoors.MOD_ID)
 public class SpookyDoorsConfigData implements BalmConfigData {
     @Comment("Make the doors randomly open slightly. Doesn't affect gameplay.")
-    @ExpectedType(Boolean.class)
-    public Boolean random_spook = Boolean.FALSE;
+    @ExpectedType(boolean.class)
+    public boolean random_spook = false;
 }

--- a/common/src/main/java/net/blay09/mods/spookydoors/block/SpookyDoorBlock.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/block/SpookyDoorBlock.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
@@ -156,6 +157,16 @@ public class SpookyDoorBlock extends DoorBlock implements EntityBlock {
             if (level.getBlockEntity(pos) instanceof SpookyDoorBlockEntity spookyDoor) {
                 spookyDoor.setOpennessBy(openness, null);
             }
+        }
+    }
+
+    @Override
+    public void setOpen(@Nullable Entity entity, Level level, BlockState state, BlockPos pos, boolean value) {
+        if (state.is(this) && state.getValue(OPEN) != value) {
+            if (level.getBlockEntity(pos) instanceof SpookyDoorBlockEntity spookyDoor) {
+                spookyDoor.setOpennessBy(value ? 1f : 0f, entity);
+            }
+            level.gameEvent(entity, value ? GameEvent.BLOCK_OPEN : GameEvent.BLOCK_CLOSE, pos);
         }
     }
 }

--- a/common/src/main/java/net/blay09/mods/spookydoors/block/entity/SpookyDoorBlockEntity.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/block/entity/SpookyDoorBlockEntity.java
@@ -3,11 +3,10 @@ package net.blay09.mods.spookydoors.block.entity;
 import net.blay09.mods.balm.api.block.entity.CustomRenderBoundingBox;
 import net.blay09.mods.balm.common.BalmBlockEntity;
 import net.blay09.mods.spookydoors.ModBlockEntities;
-import net.blay09.mods.spookydoors.ModBlocks;
 import net.blay09.mods.spookydoors.ModSounds;
+import net.blay09.mods.spookydoors.SpookyDoorsConfig;
 import net.blay09.mods.spookydoors.block.SpookyDoorBlock;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
@@ -22,6 +21,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Math;
 
@@ -30,6 +30,7 @@ public class SpookyDoorBlockEntity extends BalmBlockEntity implements CustomRend
     private static final int SYNC_INTERVAL = 1;
     private int ticksSinceLastSync = 0;
     private int soundCooldownTicks = 0;
+    private int spookCooldownTicks = 400;
     private boolean isDirty;
 
     private float openness;
@@ -135,6 +136,23 @@ public class SpookyDoorBlockEntity extends BalmBlockEntity implements CustomRend
     }
 
     public void serverTick() {
+        if (SpookyDoorsConfig.getActive().random_spook && this.getOpenness() == 0f && this.level != null) {
+            if (spookCooldownTicks > 0) {
+                spookCooldownTicks--;
+            } else {
+                spookCooldownTicks = 400;
+                if (this.level.random.nextInt(10) == 0) {
+                    boolean beingWatched = this.level.players().stream().anyMatch(player -> {
+                        Vec3 doorPlayerVec = worldPosition.getCenter().subtract(player.position());
+                        return doorPlayerVec.lengthSqr() < 1024 && player.getLookAngle().dot(doorPlayerVec.normalize()) > 0f;
+                    });
+                    if (!beingWatched) {
+                        this.setOpennessBy(0.3f, null);
+                    }
+                }
+            }
+        }
+
         ticksSinceLastSync++;
         if (ticksSinceLastSync >= SYNC_INTERVAL) {
             if (isDirty) {

--- a/common/src/main/java/net/blay09/mods/spookydoors/client/render/SpookyDoorBlockEntityRenderer.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/client/render/SpookyDoorBlockEntityRenderer.java
@@ -4,13 +4,11 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.blay09.mods.spookydoors.block.SpookyDoorBlock;
 import net.blay09.mods.spookydoors.block.entity.SpookyDoorBlockEntity;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.properties.DoorHingeSide;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
@@ -42,25 +40,17 @@ public class SpookyDoorBlockEntityRenderer implements BlockEntityRenderer<Spooky
             }
         }
 
-        final var vertexConsumer = multiBufferSource.getBuffer(RenderType.cutout());
         poseStack.pushPose();
         applyDoorPose(poseStack, baseDoor.getOpenness(), state.getValue(SpookyDoorBlock.FACING), state.getValue(SpookyDoorBlock.HINGE));
         final var stateForRender = state.setValue(SpookyDoorBlock.OPEN, false);
+        final var vertexConsumer = multiBufferSource.getBuffer(ItemBlockRenderTypes.getRenderType(state, false));
 
         int color = Minecraft.getInstance().getBlockColors().getColor(stateForRender, level, pos, 0);
         float r = (float)(color >> 16 & 0xFF) / 255.0F;
         float g = (float)(color >> 8 & 0xFF) / 255.0F;
         float b = (float)(color & 0xFF) / 255.0F;
 
-        int blockLight = (light >> 4) & 0xF;
-        int skyLight = (light >> 20) & 0xF;
-        // slightly decrease lighting
-        int shade = Math.round(1F / level.getShade(stateForRender.getValue(SpookyDoorBlock.FACING), true) + 0.1F) + 1;
-        blockLight = Math.max(0, blockLight - shade);
-        skyLight = Math.max(0, skyLight - shade);
-        int fixedLight = (blockLight << 4) | (skyLight << 20);
-
-        blockRenderDispatcher.getModelRenderer().renderModel(poseStack.last(), vertexConsumer, stateForRender, blockRenderDispatcher.getBlockModel(stateForRender), r, g, b, fixedLight, overlay);
+        blockRenderDispatcher.getModelRenderer().renderModel(poseStack.last(), vertexConsumer, stateForRender, blockRenderDispatcher.getBlockModel(stateForRender), r, g, b, light, overlay);
         poseStack.popPose();
     }
 

--- a/common/src/main/java/net/blay09/mods/spookydoors/client/render/SpookyDoorBlockEntityRenderer.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/client/render/SpookyDoorBlockEntityRenderer.java
@@ -3,6 +3,8 @@ package net.blay09.mods.spookydoors.client.render;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.blay09.mods.spookydoors.block.SpookyDoorBlock;
 import net.blay09.mods.spookydoors.block.entity.SpookyDoorBlockEntity;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
@@ -10,7 +12,6 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.Direction;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.state.properties.DoorHingeSide;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import org.joml.AxisAngle4d;
@@ -19,11 +20,9 @@ import org.joml.Quaternionf;
 public class SpookyDoorBlockEntityRenderer implements BlockEntityRenderer<SpookyDoorBlockEntity> {
 
     private final BlockRenderDispatcher blockRenderDispatcher;
-    private final RandomSource randomSource;
 
     public SpookyDoorBlockEntityRenderer(BlockEntityRendererProvider.Context context) {
         blockRenderDispatcher = context.getBlockRenderDispatcher();
-        randomSource = RandomSource.create();
     }
 
     @Override
@@ -47,7 +46,11 @@ public class SpookyDoorBlockEntityRenderer implements BlockEntityRenderer<Spooky
         poseStack.pushPose();
         applyDoorPose(poseStack, baseDoor.getOpenness(), state.getValue(SpookyDoorBlock.FACING), state.getValue(SpookyDoorBlock.HINGE));
         final var stateForRender = state.setValue(SpookyDoorBlock.OPEN, false);
-        blockRenderDispatcher.getModelRenderer().tesselateBlock(level, blockRenderDispatcher.getBlockModel(stateForRender), stateForRender, pos, poseStack, vertexConsumer, false, randomSource, stateForRender.getSeed(pos), OverlayTexture.NO_OVERLAY);
+        int color = Minecraft.getInstance().getBlockColors().getColor(stateForRender, level, pos, 0);
+        float r = (float)(color >> 16 & 0xFF) / 255.0F;
+        float g = (float)(color >> 8 & 0xFF) / 255.0F;
+        float b = (float)(color & 0xFF) / 255.0F;
+        blockRenderDispatcher.getModelRenderer().renderModel(poseStack.last(), vertexConsumer, stateForRender, blockRenderDispatcher.getBlockModel(stateForRender), r, g, b, LevelRenderer.getLightColor(level, stateForRender, pos), OverlayTexture.NO_OVERLAY);
         poseStack.popPose();
     }
 

--- a/common/src/main/java/net/blay09/mods/spookydoors/client/render/SpookyDoorBlockEntityRenderer.java
+++ b/common/src/main/java/net/blay09/mods/spookydoors/client/render/SpookyDoorBlockEntityRenderer.java
@@ -46,11 +46,21 @@ public class SpookyDoorBlockEntityRenderer implements BlockEntityRenderer<Spooky
         poseStack.pushPose();
         applyDoorPose(poseStack, baseDoor.getOpenness(), state.getValue(SpookyDoorBlock.FACING), state.getValue(SpookyDoorBlock.HINGE));
         final var stateForRender = state.setValue(SpookyDoorBlock.OPEN, false);
+
         int color = Minecraft.getInstance().getBlockColors().getColor(stateForRender, level, pos, 0);
         float r = (float)(color >> 16 & 0xFF) / 255.0F;
         float g = (float)(color >> 8 & 0xFF) / 255.0F;
         float b = (float)(color & 0xFF) / 255.0F;
-        blockRenderDispatcher.getModelRenderer().renderModel(poseStack.last(), vertexConsumer, stateForRender, blockRenderDispatcher.getBlockModel(stateForRender), r, g, b, LevelRenderer.getLightColor(level, stateForRender, pos), OverlayTexture.NO_OVERLAY);
+
+        int blockLight = (light >> 4) & 0xF;
+        int skyLight = (light >> 20) & 0xF;
+        // slightly decrease lighting
+        int shade = Math.round(1F / level.getShade(stateForRender.getValue(SpookyDoorBlock.FACING), true) + 0.1F) + 1;
+        blockLight = Math.max(0, blockLight - shade);
+        skyLight = Math.max(0, skyLight - shade);
+        int fixedLight = (blockLight << 4) | (skyLight << 20);
+
+        blockRenderDispatcher.getModelRenderer().renderModel(poseStack.last(), vertexConsumer, stateForRender, blockRenderDispatcher.getBlockModel(stateForRender), r, g, b, fixedLight, overlay);
         poseStack.popPose();
     }
 


### PR DESCRIPTION
- Replace `setOpen` with a working alternative. Now NPCs can open doors correctly.
- Fix black hinges due to incorrect lighting. Should be shader-friendly when using Oculus/Iris.
- Added new `random_spook` mechanic (disabled by default in the config file). If enabled, the mod chooses every 20 seconds if the door should slightly open. It has a 1/10 chance (should open once every 3 minutes or so) and only works if player is looking away.

I've only made these changes in 1.20.1 because I'm currently playing this version, but they should be easily portable to 1.21.11